### PR TITLE
Add Run in GraphiQL links to entries

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -46,6 +46,10 @@
   .shortEntryWrapper .header {
     width: 50%;
   }
+  .entryInner a {
+    color: rgba(111, 194, 139, 1);
+    text-decoration: none;
+  }
   .entryInner:nth-child(2n) {
     background: rgba(245, 245, 245, 1);
   }

--- a/src/components/Definition.js
+++ b/src/components/Definition.js
@@ -29,8 +29,7 @@ Operation.propTypes = {
 };
 
 
-// TODO: Change this and filename to "Definition"
-export default function Request({
+export default function Definition({
   request,
 }) {
   const { name, operations } = request;
@@ -44,6 +43,6 @@ export default function Request({
   );
 }
 
-Request.propTypes = {
+Definition.propTypes = {
   request: React.PropTypes.object.isRequired,
 };

--- a/src/components/Entry.js
+++ b/src/components/Entry.js
@@ -1,5 +1,12 @@
 import React from 'react';
-import Request from './Request';
+import Definition from './Definition';
+
+const makeGraphiQlUrl = (entry) => {
+  const base = entry.url;
+  const query = encodeURIComponent(entry.bareQuery);
+  const variables = encodeURIComponent(JSON.stringify(entry.queryVariables));
+  return `${base}/graphiql?query=${query}&variables=${variables}`;
+};
 
 export default function Entry({
   entry,
@@ -13,12 +20,15 @@ export default function Entry({
       </div>
       {entry.data && entry.data.map((request, i) => {
         if (request.kind !== 'FragmentDefinition') {
-          return <Request key={`request-${i}`} request={request} />;
+          return <Definition key={`request-${i}`} request={request} />;
         }
       })}
       {!entry.data && (
         <p className="error">{entry}</p>
       )}
+      <div className="runInGraphiQl">
+        <a target="_blank" href={makeGraphiQlUrl(entry)}>Run in GraphiQL</a>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Add "Run in GraphiQL" link to Entry components
* This link launches a new tab at the `/graphiql` path off the entry url with uri encoded query and variables as paramters per usual GraphiQL behavior

I also renamed `Response` to `Definition` per the TODO item while I was in there.  Please let me know if you'd like to revert that change.