### PR TITLE
Fix breakage when opening response tab for response without body, and other misc fixes

### DIFF
--- a/src/components/Collapsable.js
+++ b/src/components/Collapsable.js
@@ -47,7 +47,7 @@ export default class Collapsable extends React.Component {
     return (
       <div className="collapsable">
         <div className={`nameParamWrapper ${fields && closable && 'hasChildren'} ${opened ? 'opened' : 'closed'}`} onClick={() => requestOpen(object.name)}>
-          <p className="name" onClick={() => requestOpen(object.name)}>
+          <div className="name" onClick={() => requestOpen(object.name)}>
             {object.kind !== 'FragmentSpread' && object.name}
             {object.kind === 'FragmentSpread' && (
               <Computed
@@ -55,7 +55,7 @@ export default class Collapsable extends React.Component {
                 fragments={fragments}
               />
             )}
-          </p>
+          </div>
           {object.params && object.params.length > 0 && (
             <div className="params">
               {object.params.map(param => (

--- a/src/components/Collapsable.js
+++ b/src/components/Collapsable.js
@@ -8,9 +8,13 @@ export default class Collapsable extends React.Component {
     object: React.PropTypes.object.isRequired,
     topLevel: React.PropTypes.bool,
     opened: React.PropTypes.bool,
-    requestOpen: React.PropTypes.func.isRequired,
+    requestOpen: React.PropTypes.func,
     fragments: React.PropTypes.array.isRequired,
     closable: React.PropTypes.bool.isRequired,
+  };
+
+  static defaultProps = {
+    requestOpen: () => {},
   };
 
   constructor(props) {

--- a/src/components/Collapsable.js
+++ b/src/components/Collapsable.js
@@ -58,8 +58,8 @@ export default class Collapsable extends React.Component {
           </div>
           {object.params && object.params.length > 0 && (
             <div className="params">
-              {object.params.map(param => (
-                <div className="param">
+              {object.params.map((param, i) => (
+                <div className="param" key={`param-${i}`}>
                   <span className="paramName">{param.name}</span>
                   <Value value={param.value} kind={param.kind} />
                 </div>
@@ -69,13 +69,14 @@ export default class Collapsable extends React.Component {
         </div>
         {fields && opened && (
           <div className="fields">
-            {fields.map(field => (
+            {fields.map((field, i) => (
               <Collapsable
                 closable
                 object={field}
                 fragments={fragments}
                 opened={openChildren.indexOf(field.name) !== -1}
                 requestOpen={this.openIsRequested}
+                key={`field-${i}`}
               />
             ))}
           </div>

--- a/src/components/Computed.js
+++ b/src/components/Computed.js
@@ -8,8 +8,8 @@ export default function Computed({
   const { operations } = request;
   return (
     <div className="computed">
-      {operations.map(x => (
-        <div className="computed-operation">
+      {operations.map((x, i) => (
+        <div className="computed-operation" key={`computed-operation-${i}`}>
           <Collapsable
             closable={false}
             object={x}

--- a/src/components/Request.js
+++ b/src/components/Request.js
@@ -37,8 +37,8 @@ export default function Request({
   return (
     <div className={'request'}>
       <span>{`- ${name}`}</span>
-      {operations.map(x => (
-        <Operation operation={x} />
+      {operations.map((x, i) => (
+        <Operation operation={x} key={`operation-${i}`}/>
       ))}
     </div>
   );

--- a/src/components/Response.js
+++ b/src/components/Response.js
@@ -7,17 +7,21 @@ export default function Response({
   return (
     <div className="response">
       <h3>Response</h3>
-      <div className="responseJson">
-        <CollapsableObject
-          object={response}
-          topLevel
-          open
-        />
-      </div>
+      {response != null ? (
+        <div className="responseJson">
+          <CollapsableObject
+            object={response}
+            topLevel
+            open
+          />
+        </div>
+      ) : (
+        <em>empty response body</em>
+      )}
     </div>
   );
 }
 
 Response.propTypes = {
-  response: React.PropTypes.string.isRequired,
+  response: React.PropTypes.object,
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -134,7 +134,7 @@ export function parseEntry(entry) {
 
   return new Promise(resolve => {
     entry.getContent(responseBody => {
-      const parsedResponseBody = JSON.parse(responseBody);
+      const parsedResponseBody = (typeof responseBody === 'string' && responseBody.length === 0) ? null : JSON.parse(responseBody);
 
       resolve(parsedQueries.map((parsedQuery, i) => {
         return {


### PR DESCRIPTION
There was a bug where if a response did not have a body and the Response tab was opened. The `LongInformation` component would stop updating and would no longer switch to other tabs or entries. This PR contains a fix, along with some other miscellaneous fixes 🙂